### PR TITLE
fix(helpers): replace .toQuery() interpolation in sanitizeAndEscapeDots

### DIFF
--- a/packages/nocodb/src/helpers/sqlSanitize.ts
+++ b/packages/nocodb/src/helpers/sqlSanitize.ts
@@ -16,18 +16,11 @@ export function sanitizeAndEscapeDots(alias: string, knex: XKnex) {
   const sanitizedAlias = sanitize(alias);
   // if alias does not contain any dot then return as it is
   if (!knex || !sanitizedAlias.includes('.')) return sanitizedAlias;
-  // if alias contains dot then return knex.raw with escaped dot
-  switch (knex?.clientType?.()) {
-    case 'mysql':
-    case 'mysql2':
-      return knex.raw(
-        knex.raw('??', sanitizedAlias).toQuery().replace(/`\.`/g, '.'),
-      );
-    case 'pg':
-      return knex.raw(
-        knex.raw('??', sanitizedAlias).toQuery().replace(/"\."/g, '.'),
-      );
-    default:
-      return sanitizedAlias;
-  }
+
+  // Split on dots and bind each identifier part individually via Knex's
+  // ?? placeholder. This keeps parameterization intact without .toQuery()
+  // string interpolation followed by regex replacement.
+  const parts = sanitizedAlias.split('.');
+  const placeholders = parts.map(() => '??').join('.');
+  return knex.raw(placeholders, parts);
 }


### PR DESCRIPTION
sanitizeAndEscapeDots() converts a Knex identifier to a raw SQL
string via .toQuery(), then uses regex to undo dot escaping —
breaking Knex's binding chain.

Replace with split-and-bind: each dot-separated identifier part
is parameterized individually via Knex's ?? binding.

Fixes #6